### PR TITLE
Build Crystal from source for each platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,12 +39,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3.0.2
 
-      # - name: Docker Setup QEMU
-      #   uses: docker/setup-qemu-action@v2.0.0
-
-      # - name: Docker Setup Buildx
-      #   uses: docker/setup-buildx-action@v2.0.0
-
       - name: Set up Depot CLI
         uses: depot/setup-action@v1
 
@@ -87,19 +81,6 @@ jobs:
           cache-from: ${{ steps.cache.outputs.cache-from }}
           cache-to: ${{ steps.cache.outputs.cache-to }}
 
-      # - name: Build Docker images
-      #   uses: docker/build-push-action@v3.0.0
-      #   with:
-      #     context: docker/${{ matrix.crystal_major_minor }}
-      #     tags: ${{ steps.meta.outputs.tags }}
-      #     labels: ${{ steps.meta.outputs.labels }}
-      #     platforms: |
-      #       linux/amd64,linux/arm64
-      #     pull: true
-      #     push: true
-      #     cache-from: ${{ steps.cache.outputs.cache-from }}
-      #     cache-to: ${{ steps.cache.outputs.cache-to }}
-
       # - name: Install Goss
       #   uses: e1himself/goss-installation-action@v1.0.4
       #   with:
@@ -114,15 +95,3 @@ jobs:
       #   with:
       #     image: local-image:ci
       #     config-file: ${{ github.workspace }}/.dive-ci.yml
-
-      # - name: Push Docker images
-      #   uses: docker/build-push-action@v3.0.0
-      #   with:
-      #     context: docker/${{ matrix.crystal_major_minor }}
-      #     tags: ${{ steps.meta.outputs.tags }}
-      #     labels: ${{ steps.meta.outputs.labels }}
-      #     platforms: |
-      #       linux/amd64,linux/arm64
-      #     push: ${{ github.event_name != 'pull_request' }}
-      #     cache-from: ${{ steps.cache.outputs.cache-from }}
-      #     cache-to: ${{ steps.cache.outputs.cache-to }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ jobs:
       matrix:
         include:
           - { crystal_major_minor: 1.5, crystal_full: 1.5.1 }
-          - { crystal_major_minor: 1.4, crystal_full: 1.4.1 }
-          - { crystal_major_minor: 1.3, crystal_full: 1.3.2 }
-          - { crystal_major_minor: 1.2, crystal_full: 1.2.2 }
+          # - { crystal_major_minor: 1.4, crystal_full: 1.4.1 }
+          # - { crystal_major_minor: 1.3, crystal_full: 1.3.2 }
+          # - { crystal_major_minor: 1.2, crystal_full: 1.2.2 }
 
     name: >-
       Crystal ${{ matrix.crystal_full }}
@@ -28,11 +28,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3.0.2
 
-      - name: Docker Setup QEMU
-        uses: docker/setup-qemu-action@v2.0.0
+      # - name: Docker Setup QEMU
+      #   uses: docker/setup-qemu-action@v2.0.0
 
-      - name: Docker Setup Buildx
-        uses: docker/setup-buildx-action@v2.0.0
+      # - name: Docker Setup Buildx
+      #   uses: docker/setup-buildx-action@v2.0.0
+
+      - name: Set up Depot CLI
+        uses: depot/setup-action@v1
 
       - name: Docker GitHub Registry Login
         uses: docker/login-action@v2.0.0
@@ -50,8 +53,8 @@ jobs:
           images: |
             ghcr.io/luislavena/hydrofoil-crystal
           tags: |
-            type=raw,${{ matrix.crystal_full }}
-            type=raw,${{ matrix.crystal_major_minor }}
+            type=raw,${{ matrix.crystal_full }}-pr42
+            type=raw,${{ matrix.crystal_major_minor }}-pr42
 
       - name: Setup Docker BuildKit cache strategy
         uses: int128/docker-build-cache-config-action@v1.9.0
@@ -61,24 +64,39 @@ jobs:
           tag-prefix: crystal-${{ matrix.crystal_major_minor }}--
 
       - name: Build Docker images
-        uses: docker/build-push-action@v3.0.0
+        uses: depot/build-push-action@v1
         with:
+          project: ${{ secrets.DEPOT_PROJECT_ID }}
+          token: ${{ secrets.DEPOT_PROJECT_TOKEN }}
           context: docker/${{ matrix.crystal_major_minor }}
-          tags: local-image:ci
-          load: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           platforms: |
-            linux/amd64
-          pull: true
+            linux/amd64,linux/arm64
+          push: true
           cache-from: ${{ steps.cache.outputs.cache-from }}
           cache-to: ${{ steps.cache.outputs.cache-to }}
 
-      - name: Install Goss
-        uses: e1himself/goss-installation-action@v1.0.4
-        with:
-          version: 'v0.3.16'
+      # - name: Build Docker images
+      #   uses: docker/build-push-action@v3.0.0
+      #   with:
+      #     context: docker/${{ matrix.crystal_major_minor }}
+      #     tags: ${{ steps.meta.outputs.tags }}
+      #     labels: ${{ steps.meta.outputs.labels }}
+      #     platforms: |
+      #       linux/amd64,linux/arm64
+      #     pull: true
+      #     push: true
+      #     cache-from: ${{ steps.cache.outputs.cache-from }}
+      #     cache-to: ${{ steps.cache.outputs.cache-to }}
 
-      - name: Test Docker image
-        run: dgoss run local-image:ci sleep infinity
+      # - name: Install Goss
+      #   uses: e1himself/goss-installation-action@v1.0.4
+      #   with:
+      #     version: 'v0.3.16'
+
+      # - name: Test Docker image
+      #   run: dgoss run local-image:ci sleep infinity
 
       # FIXME: Use latest version of Dive
       # - name: Analyze image efficiency
@@ -87,14 +105,14 @@ jobs:
       #     image: local-image:ci
       #     config-file: ${{ github.workspace }}/.dive-ci.yml
 
-      - name: Push Docker images
-        uses: docker/build-push-action@v3.0.0
-        with:
-          context: docker/${{ matrix.crystal_major_minor }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: |
-            linux/amd64
-          push: ${{ github.event_name != 'pull_request' }}
-          cache-from: ${{ steps.cache.outputs.cache-from }}
-          cache-to: ${{ steps.cache.outputs.cache-to }}
+      # - name: Push Docker images
+      #   uses: docker/build-push-action@v3.0.0
+      #   with:
+      #     context: docker/${{ matrix.crystal_major_minor }}
+      #     tags: ${{ steps.meta.outputs.tags }}
+      #     labels: ${{ steps.meta.outputs.labels }}
+      #     platforms: |
+      #       linux/amd64,linux/arm64
+      #     push: ${{ github.event_name != 'pull_request' }}
+      #     cache-from: ${{ steps.cache.outputs.cache-from }}
+      #     cache-to: ${{ steps.cache.outputs.cache-to }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,8 +64,8 @@ jobs:
           images: |
             ghcr.io/luislavena/hydrofoil-crystal
           tags: |
-            type=raw,${{ matrix.crystal_full }}-pr42
-            type=raw,${{ matrix.crystal_major_minor }}-pr42
+            type=raw,${{ matrix.crystal_full }}
+            type=raw,${{ matrix.crystal_major_minor }}
 
       - name: Setup Docker BuildKit cache strategy
         uses: int128/docker-build-cache-config-action@v1.9.0
@@ -83,7 +83,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: ${{ matrix.target_platforms }}
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           cache-from: ${{ steps.cache.outputs.cache-from }}
           cache-to: ${{ steps.cache.outputs.cache-to }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,21 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { crystal_major_minor: 1.5, crystal_full: 1.5.1 }
-          # - { crystal_major_minor: 1.4, crystal_full: 1.4.1 }
-          # - { crystal_major_minor: 1.3, crystal_full: 1.3.2 }
-          # - { crystal_major_minor: 1.2, crystal_full: 1.2.2 }
+          - crystal_major_minor: 1.5
+            crystal_full: 1.5.1
+            target_platforms: linux/amd64,linux/arm64
+
+          - crystal_major_minor: 1.4
+            crystal_full: 1.4.1
+            target_platforms: linux/amd64
+
+          - crystal_major_minor: 1.3
+            crystal_full: 1.3.2
+            target_platforms: linux/amd64
+
+          - crystal_major_minor: 1.2
+            crystal_full: 1.2.2
+            target_platforms: linux/amd64
 
     name: >-
       Crystal ${{ matrix.crystal_full }}
@@ -71,8 +82,7 @@ jobs:
           context: docker/${{ matrix.crystal_major_minor }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: |
-            linux/amd64,linux/arm64
+          platforms: ${{ matrix.target_platforms }}
           push: true
           cache-from: ${{ steps.cache.outputs.cache-from }}
           cache-to: ${{ steps.cache.outputs.cache-to }}

--- a/docker/1.5/Dockerfile
+++ b/docker/1.5/Dockerfile
@@ -1,20 +1,188 @@
-# syntax = docker/dockerfile:1.3
+# syntax=docker/dockerfile:1.3
 
 # ---
-# 1. Use Alpine as base
-FROM alpine:3.16 AS base
+# Stages:
+#
+# stage0: use build platform and existing compiler to cross-compile for target
+# stage1: link cross-compiled objects into executables on the target platform
+# stage2: prepare directory structure, source code and final executables
+# stage3: copy over artifacts and development utilities and dependencies
 
 # ---
-# 2. Upgrade system and installed dependencies for security patches
-RUN --mount=type=cache,target=/var/cache/apk \
+# stage0: bootstrap Crystal using Alpine's build of Crystal
+FROM --platform=$BUILDPLATFORM alpine:3.16 AS stage0
+
+# expose the target architecture to be used in cross-compilation
+ARG TARGETARCH
+
+# install dependencies needed for cross-compilation of Crystal and Shards
+RUN --mount=type=cache,sharing=private,target=/var/cache/apk \
+    set -eux; \
+    apk add \
+        crystal \
+        curl \
+        g++ \
+        git \
+        llvm13-dev \
+        make \
+        shards \
+        yaml-dev \
+    ;
+
+# download and compile Crystal source for target platform
+RUN set -eux; \
+    cd /tmp; \
+    export \
+        CRYSTAL_VERSION=1.5.1 \
+        CRYSTAL_SHA256=d6d2ed257c688a81c68bad63a9796d34aab3a5667f7e3a86d22f9fce2f8c56fc \
+    ; \
+    { \
+        curl --fail -Lo crystal.tar.gz https://github.com/crystal-lang/crystal/archive/refs/tags/${CRYSTAL_VERSION}.tar.gz; \
+        echo "${CRYSTAL_SHA256} *crystal.tar.gz" | sha256sum -c - >/dev/null 2>&1; \
+        tar -xf crystal.tar.gz; \
+        rm crystal.tar.gz; \
+        mv crystal-${CRYSTAL_VERSION} crystal; \
+    }; \
+    { \
+        cd /tmp/crystal; \
+        # prepare man page
+        gzip -9 man/crystal.1; \
+        mkdir -p /usr/local/share/man/man1; \
+        cp -f man/*.1.gz /usr/local/share/man/man1/; \
+        # build Compiler for target architecture
+        mkdir -p .build; \
+        make crystal release=1 static=1 target=$TARGETARCH-alpine-linux-musl | tail -1 | tee .build/crystal.sh; \
+        rm -rf src/llvm/ext/llvm_ext.o; \
+    }
+
+# download and compile Shards source for target platform
+RUN set -eux; \
+    cd /tmp; \
+    export \
+        SHARDS_VERSION=0.17.0 \
+        SHARDS_SHA256=b3f0a2261437b21b3e2465b7755edf0c33f0305a112bd9a36e1b3ec74f96b098 \
+    ; \
+    { \
+        curl --fail -Lo shards.tar.gz https://github.com/crystal-lang/shards/archive/refs/tags/v${SHARDS_VERSION}.tar.gz; \
+        echo "${SHARDS_SHA256} *shards.tar.gz" | sha256sum -c - >/dev/null 2>&1; \
+        tar -xf shards.tar.gz; \
+        rm shards.tar.gz; \
+        mv shards-${SHARDS_VERSION} shards; \
+    }; \
+    { \
+        cd /tmp/shards; \
+        # prepare man pages
+        gzip -9 man/shards.1 man/shard.yml.5; \
+        mkdir -p /usr/local/share/man/man1 /usr/local/share/man/man5; \
+        cp -f man/*.1.gz /usr/local/share/man/man1/; \
+        cp -f man/*.5.gz /usr/local/share/man/man5/; \
+        # build for target platform
+        make bin/shards release=1 static=1 FLAGS="--cross-compile --target $TARGETARCH-alpine-linux-musl" | tail -1 | tee bin/shards.sh; \
+    }
+
+# ---
+# stage1: link compiled objects on target platform
+FROM alpine:3.16 AS stage1
+
+# install dependencies needed for linking
+RUN --mount=type=cache,sharing=private,target=/var/cache/apk \
+    set -eux; \
+    apk add \
+        g++ \
+        gc-dev \
+        gcc \
+        git \
+        libevent-static \
+        libxml2-dev \
+        llvm13-dev \
+        llvm13-static \
+        make \
+        musl-dev \
+        pcre-dev \
+        yaml-static \
+        zlib-static \
+    ;
+
+# copy build artifacts from stage0
+COPY --from=stage0 /tmp/crystal/.build /tmp/crystal/.build
+COPY --from=stage0 /tmp/crystal/Makefile /tmp/crystal/Makefile
+COPY --from=stage0 /tmp/crystal/src/llvm/ext /tmp/crystal/src/llvm/ext
+COPY --from=stage0 /tmp/shards/bin /tmp/shards/bin
+
+# link objects to final binaries
+RUN set -eux; \
+    # compile LLVM extension and link the compiler
+    { \
+        cd /tmp/crystal; \
+        mkdir -p spec/; \
+        make llvm_ext; \
+        sh -ex .build/crystal.sh; \
+        # smoke test
+        .build/crystal --version; \
+        # copy final binary
+        mkdir -p /tmp/usr/local/bin; \
+        cp -f .build/crystal /tmp/usr/local/bin/; \
+    }; \
+    # compile shards
+    { \
+        cd /tmp/shards; \
+        sh -ex bin/shards.sh; \
+        # smoke test
+        bin/shards --version; \
+        # copy final binary
+        mkdir -p /tmp/usr/local/bin; \
+        cp -f bin/shards /tmp/usr/local/bin/; \
+    }
+
+# ---
+# stage2: prepare binaries and code for final image
+FROM alpine:3.16 AS stage2
+
+# combine source code and final binaries from previous stages
+COPY --from=stage0 /tmp/crystal/src /usr/local/share/crystal/src
+COPY --from=stage0 /usr/local/share/man /usr/local/share/man
+COPY --from=stage1 /tmp/usr/local/bin /usr/local/bin
+
+# ---
+# stage3: final image
+FROM alpine:3.16 AS stage3
+
+# upgrade system and installed dependencies for security patches
+RUN --mount=type=cache,sharing=private,target=/var/cache/apk \
     set -eux; \
     apk upgrade
 
-# ---
-# 3. Setup non-root user (fixuid)
-#
-# TODO: detect arch other than x86_64
-RUN --mount=type=cache,target=/var/cache/apk \
+# copy prepared structure from stage2
+COPY --from=stage2 /usr/local /usr/local
+
+# install dependencies and common packages
+RUN --mount=type=cache,sharing=private,target=/var/cache/apk \
+    set -eux; \
+    apk add \
+        curl \
+        gc-dev \
+        gcc \
+        git \
+        libevent-static \
+        musl-dev \
+        openssl-dev \
+        openssl-libs-static \
+        pcre-dev \
+        sqlite-static \
+        tzdata \
+        yaml-dev \
+        yaml-static \
+        zlib-dev \
+        zlib-static \
+    ; \
+    # smoke tests
+    [ "$(command -v crystal)" = '/usr/local/bin/crystal' ]; \
+    [ "$(command -v shards)" = '/usr/local/bin/shards' ]; \
+    crystal --version; \
+    shards --version
+
+# setup non-root user (fixuid)
+RUN --mount=type=cache,sharing=private,target=/var/cache/apk \
     --mount=type=tmpfs,target=/tmp \
     set -eux; \
     # create non-root user & give passwordless sudo
@@ -30,9 +198,22 @@ RUN --mount=type=cache,target=/var/cache/apk \
     # Install fixuid
     { \
         cd /tmp; \
-        export FIXUID_VERSION=0.5.1 \
-            FIXUID_SHA256=1077e7af13596e6e3902230d7260290fe21b2ee4fffcea1eb548e5c465a34800; \
-        wget -q -O fixuid.tar.gz https://github.com/boxboat/fixuid/releases/download/v${FIXUID_VERSION}/fixuid-${FIXUID_VERSION}-linux-amd64.tar.gz; \
+        export FIXUID_VERSION=0.5.1; \
+        case "$(arch)" in \
+        x86_64) \
+            export \
+                FIXUID_ARCH=amd64 \
+                FIXUID_SHA256=1077e7af13596e6e3902230d7260290fe21b2ee4fffcea1eb548e5c465a34800 \
+            ; \
+            ;; \
+        aarch64) \
+            export \
+                FIXUID_ARCH=arm64 \
+                FIXUID_SHA256=7993a03876f5151c450e68a49706ef4c80d6b0ab755679eb47282df7f162fd82 \
+            ; \
+            ;; \
+        esac; \
+        wget -q -O fixuid.tar.gz https://github.com/boxboat/fixuid/releases/download/v${FIXUID_VERSION}/fixuid-${FIXUID_VERSION}-linux-${FIXUID_ARCH}.tar.gz; \
         echo "${FIXUID_SHA256} *fixuid.tar.gz" | sha256sum -c - >/dev/null 2>&1; \
         tar -xf fixuid.tar.gz; \
         mv fixuid /usr/local/bin/; \
@@ -50,71 +231,32 @@ RUN --mount=type=cache,target=/var/cache/apk \
 ENTRYPOINT [ "/usr/local/bin/fixuid", "-q" ]
 CMD [ "/bin/sh" ]
 
-# ---
-# 4. Install Crystal dependencies & common packages
-RUN --mount=type=cache,target=/var/cache/apk \
-    set -eux; \
-    apk add \
-        curl \
-        gc-dev \
-        gcc \
-        git \
-        libevent-static \
-        musl-dev \
-        openssl-dev \
-        openssl-libs-static \
-        pcre-dev \
-        sqlite-static \
-        tzdata \
-        yaml-static \
-        zlib-dev \
-        zlib-static \
-    ;
-
-# ---
-# 5. Download and extract Crystal
-#
-# TODO: detect arch other than x86_64
-RUN --mount=type=tmpfs,target=/tmp \
-    set -eux; \
-    export \
-        CRYSTAL_VERSION=1.5.1 \
-        CRYSTAL_SHA256=a475c3d99dbe0f2d5a72d471fa25e03c124b599e47336eed746973b4b4d787bc; \
-    cd /tmp; \
-    { \
-        curl --fail -Lo crystal.tar.gz https://github.com/crystal-lang/crystal/releases/download/${CRYSTAL_VERSION}/crystal-${CRYSTAL_VERSION}-1-linux-x86_64.tar.gz; \
-        echo "${CRYSTAL_SHA256} *crystal.tar.gz" | sha256sum -c - >/dev/null 2>&1; \
-        tar -xf crystal.tar.gz; \
-        rm crystal-${CRYSTAL_VERSION}-1/lib/crystal/libgc.a; \
-        mv crystal-${CRYSTAL_VERSION}-1 /usr/local/crystal; \
-        rm crystal.tar.gz; \
-    }; \
-    # smoke test
-    PATH=/usr/local/crystal/bin:$PATH; \
-    [ "$(command -v crystal)" = '/usr/local/crystal/bin/crystal' ]; \
-    [ "$(command -v shards)" = '/usr/local/crystal/bin/shards' ]; \
-    crystal --version; \
-    shards --version
-
-ENV PATH /usr/local/crystal/bin:$PATH
-
-# ---
-# 6. Install development utilities
-#
-# TODO: Support arch other than x86_64
-RUN --mount=type=cache,target=/var/cache/apk \
+# install development utilities
+RUN --mount=type=cache,sharing=private,target=/var/cache/apk \
     --mount=type=tmpfs,target=/tmp \
     set -eux; \
     cd /tmp; \
     # Overmind (needs tmux)
     { \
+        export OVERMIND_VERSION=2.3.0; \
+        case "$(arch)" in \
+        x86_64) \
+            export \
+                OVERMIND_ARCH=amd64 \
+                OVERMIND_SHA256=d6a715c0810ceb39c94bf61843befebe04a83a0469b53d6af0a52e2fea4e2ab3 \
+            ; \
+            ;; \
+        aarch64) \
+            export \
+                OVERMIND_ARCH=arm64 \
+                OVERMIND_SHA256=ac6bed32200963977e9e14e2b5228c3b1ecd25be3279bfa41c44cdbf555f1217 \
+            ; \
+            ;; \
+        esac; \
         apk add \
             tmux \
         ; \
-        export \
-            OVERMIND_VERSION=2.3.0 \
-            OVERMIND_SHA256=d6a715c0810ceb39c94bf61843befebe04a83a0469b53d6af0a52e2fea4e2ab3; \
-        curl --fail -Lo overmind.gz https://github.com/DarthSim/overmind/releases/download/v${OVERMIND_VERSION}/overmind-v${OVERMIND_VERSION}-linux-amd64.gz; \
+        curl --fail -Lo overmind.gz https://github.com/DarthSim/overmind/releases/download/v${OVERMIND_VERSION}/overmind-v${OVERMIND_VERSION}-linux-${OVERMIND_ARCH}.gz; \
         echo "${OVERMIND_SHA256} *overmind.gz" | sha256sum -c - >/dev/null 2>&1; \
         gunzip overmind.gz; \
         chmod +x overmind; \
@@ -122,14 +264,26 @@ RUN --mount=type=cache,target=/var/cache/apk \
     }; \
     # Watchexec
     { \
-        export \
-            WATCHEXEC_VERSION=1.20.6 \
-            WATCHEXEC_SHA256=6e746704b61d4a2a467546930a837ceef3a4003fc568e574cf6f43a798a4ab00; \
-        curl --fail -Lo watchexec.tar.xz https://github.com/watchexec/watchexec/releases/download/v${WATCHEXEC_VERSION}/watchexec-${WATCHEXEC_VERSION}-x86_64-unknown-linux-musl.tar.xz; \
+        export WATCHEXEC_VERSION=1.20.6; \
+        case "$(arch)" in \
+        x86_64) \
+            export \
+                WATCHEXEC_ARCH=x86_64 \
+                WATCHEXEC_SHA256=6e746704b61d4a2a467546930a837ceef3a4003fc568e574cf6f43a798a4ab00 \
+            ; \
+            ;; \
+        aarch64) \
+            export \
+                WATCHEXEC_ARCH=aarch64 \
+                WATCHEXEC_SHA256=0c9fd0f8013d30330ba0116dd8a4f77060cb55277825ebcc1b2f63aca3dc5d36 \
+            ; \
+            ;; \
+        esac; \
+        curl --fail -Lo watchexec.tar.xz https://github.com/watchexec/watchexec/releases/download/v${WATCHEXEC_VERSION}/watchexec-${WATCHEXEC_VERSION}-${WATCHEXEC_ARCH}-unknown-linux-musl.tar.xz; \
         echo "${WATCHEXEC_SHA256} *watchexec.tar.xz" | sha256sum -c - >/dev/null 2>&1; \
         tar -xf watchexec.tar.xz; \
-        mv watchexec-${WATCHEXEC_VERSION}-x86_64-unknown-linux-musl/watchexec /usr/local/bin/; \
-        rm -rf watchexec.tar.xz watchexec-${WATCHEXEC_VERSION}-x86_64-unknown-linux-musl; \
+        mv watchexec-${WATCHEXEC_VERSION}-${WATCHEXEC_ARCH}-unknown-linux-musl/watchexec /usr/local/bin/; \
+        rm -rf watchexec.tar.xz watchexec-${WATCHEXEC_VERSION}-${WATCHEXEC_ARCH}-unknown-linux-musl; \
     }; \
     # smoke tests
     [ "$(command -v overmind)" = '/usr/local/bin/overmind' ]; \


### PR DESCRIPTION
Use source package instead of official binaries with the objective of keeping debug symbols and other details useful during development (and possible in the future enable the interpreter mode).
    
This process is achieved in multiple stages, first bootstrapping using existing Alpine's Crystal+Shards version to produce object files that later are linked into the target executables, which then is combined with development packages and utilities.

Each Dockerfile uses the following multi-stage sequence:

- stage0: use build platform and existing compiler to cross-compile to target
- stage1: link cross-compiled objects into executables on the target platform
- stage2: prepare directory structure, source code and final executables
- stage3: copy over artifacts and development utilities and dependencies

Note the mentions of _build platform_ and _target platform_, as this Dockerfile is prepared to cross-compile to different targets using Docker's BuildKit functionality (Eg. compile for arm64 using amd64 host). This is necessary to prepare for the introduction of multi-architecture container images.