### PR TITLE
Use concurrency group to limit parallel compiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,12 @@ jobs:
           - crystal_major_minor: 1.6
             crystal_full: 1.6.2
             target_platforms: linux/amd64,linux/arm64
+            concurrency_group: compile-crystal
 
           - crystal_major_minor: 1.5
             crystal_full: 1.5.1
             target_platforms: linux/amd64,linux/arm64
+            concurrency_group: compile-crystal
 
           - crystal_major_minor: 1.4
             crystal_full: 1.4.1
@@ -38,6 +40,9 @@ jobs:
 
     name: >-
       Crystal ${{ matrix.crystal_full }}
+    
+    concurrency:
+      group: ${{ matrix.concurrency_group || format('{0}-{1}', github.run_id, matrix.crystal_full) }}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
This will limit the concurrency of jobs that compile Crystal, to avoid running out of system memory.